### PR TITLE
cachestorectl package

### DIFF
--- a/_examples/memlru/main.go
+++ b/_examples/memlru/main.go
@@ -5,17 +5,11 @@ import (
 	"fmt"
 
 	"github.com/goware/cachestore/cachestorectl"
-	"github.com/goware/cachestore/redis"
+	"github.com/goware/cachestore/memlru"
 )
 
 func main() {
-	cfg := &redis.Config{
-		Enabled: true,
-		Host:    "localhost",
-		Port:    6379,
-	}
-
-	backend := redis.Backend(cfg)
+	backend := memlru.Backend(5)
 
 	store, err := cachestorectl.Open[string](backend)
 	if err != nil {

--- a/_examples/memlru/main.go
+++ b/_examples/memlru/main.go
@@ -3,36 +3,78 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/goware/cachestore"
 	"github.com/goware/cachestore/cachestorectl"
 	"github.com/goware/cachestore/memlru"
 )
 
 func main() {
-	backend := memlru.Backend(5)
+	backend := memlru.Backend(200, cachestore.WithDefaultKeyExpiry(1*time.Second))
 
-	store, err := cachestorectl.Open[string](backend)
+	store, err := cachestorectl.Open[string](backend) //, cachestore.WithDefaultKeyExpiry(1*time.Second))
 	if err != nil {
 		panic(err)
 	}
 
 	ctx := context.Background()
 
-	{
-		for i := 0; i < 100; i++ {
-			err = store.Set(ctx, fmt.Sprintf("foo:%d", i), fmt.Sprintf("value-%d", i))
-			if err != nil {
-				panic(err)
-			}
-		}
-
-		err = store.DeletePrefix(ctx, "foo")
+	// Set
+	for i := 0; i < 100; i++ {
+		err = store.Set(ctx, fmt.Sprintf("foo:%d", i), fmt.Sprintf("value-%d", i))
 		if err != nil {
 			panic(err)
 		}
-
-		fmt.Println("done.")
-		fmt.Println("")
 	}
+
+	store.SetEx(ctx, "foo:999", "value-999", 10*time.Minute)
+
+	// Get
+	v, ok, err := store.Get(ctx, "foo:10")
+	if err != nil {
+		panic(err)
+	}
+	if !ok {
+		panic("unexpected")
+	}
+	fmt.Println("=> get(foo:10) =", v)
+
+	time.Sleep(5 * time.Second)
+
+	// should expire based on rule above
+	v, ok, err = store.Get(ctx, "foo:10")
+	if err != nil {
+		panic(err)
+	}
+	if ok {
+		panic("unexpected")
+	}
+	fmt.Println("=> get(foo:10) =", v)
+
+	// should still have
+	v, ok, err = store.Get(ctx, "foo:999")
+	if err != nil {
+		panic(err)
+	}
+	if !ok {
+		panic("unexpected")
+	}
+	fmt.Println("=> get(foo:999) =", v)
+
+	// DeletePrefix
+	err = store.DeletePrefix(ctx, "foo")
+	if err != nil {
+		panic(err)
+	}
+
+	// be gone
+	_, ok, _ = store.Get(ctx, "foo:999")
+	if ok {
+		panic("unexpected")
+	}
+
+	fmt.Println("done.")
+	fmt.Println("")
 
 }

--- a/_examples/redis/main.go
+++ b/_examples/redis/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/goware/cachestore"
 	"github.com/goware/cachestore/cachestorectl"
 	"github.com/goware/cachestore/redis"
 )
@@ -15,30 +17,69 @@ func main() {
 		Port:    6379,
 	}
 
-	backend := redis.Backend(cfg)
+	backend := redis.Backend(cfg) //, cachestore.WithDefaultKeyExpiry(1*time.Second))
 
-	store, err := cachestorectl.Open[string](backend)
+	store, err := cachestorectl.Open[string](backend, cachestore.WithDefaultKeyExpiry(1*time.Second))
 	if err != nil {
 		panic(err)
 	}
 
 	ctx := context.Background()
 
-	{
-		for i := 0; i < 100; i++ {
-			err = store.Set(ctx, fmt.Sprintf("foo:%d", i), fmt.Sprintf("value-%d", i))
-			if err != nil {
-				panic(err)
-			}
-		}
-
-		err = store.DeletePrefix(ctx, "foo")
+	// Set
+	for i := 0; i < 100; i++ {
+		err = store.Set(ctx, fmt.Sprintf("foo:%d", i), fmt.Sprintf("value-%d", i))
 		if err != nil {
 			panic(err)
 		}
-
-		fmt.Println("done.")
-		fmt.Println("")
 	}
 
+	store.SetEx(ctx, "foo:999", "value-999", 10*time.Minute)
+
+	// Get
+	v, ok, err := store.Get(ctx, "foo:10")
+	if err != nil {
+		panic(err)
+	}
+	if !ok {
+		panic("unexpected")
+	}
+	fmt.Println("=> get(foo:10) =", v)
+
+	time.Sleep(2 * time.Second)
+
+	// should expire based on rule above
+	v, ok, err = store.Get(ctx, "foo:10")
+	if err != nil {
+		panic(err)
+	}
+	if ok {
+		panic("unexpected")
+	}
+	fmt.Println("=> get(foo:10) =", v)
+
+	// should still have
+	v, ok, err = store.Get(ctx, "foo:999")
+	if err != nil {
+		panic(err)
+	}
+	if !ok {
+		panic("unexpected")
+	}
+	fmt.Println("=> get(foo:999) =", v)
+
+	// DeletePrefix
+	err = store.DeletePrefix(ctx, "foo")
+	if err != nil {
+		panic(err)
+	}
+
+	// be gone
+	_, ok, _ = store.Get(ctx, "foo:999")
+	if ok {
+		panic("unexpected")
+	}
+
+	fmt.Println("done.")
+	fmt.Println("")
 }

--- a/cachestore.go
+++ b/cachestore.go
@@ -48,3 +48,7 @@ type Store[V any] interface {
 	// or testing, and never in practice.
 	ClearAll(ctx context.Context) error
 }
+
+type Backend interface {
+	Config() any
+}

--- a/cachestore.go
+++ b/cachestore.go
@@ -50,5 +50,5 @@ type Store[V any] interface {
 }
 
 type Backend interface {
-	Config() any
+	Apply(*StoreOptions)
 }

--- a/cachestorectl/cachestorectl.go
+++ b/cachestorectl/cachestorectl.go
@@ -1,0 +1,22 @@
+package cachestorectl
+
+import (
+	"fmt"
+
+	"github.com/goware/cachestore"
+	"github.com/goware/cachestore/memlru"
+)
+
+func Open[T any](backend cachestore.Backend) (cachestore.Store[T], error) {
+	config := backend.Config()
+
+	switch t := config.(type) {
+
+	case *memlru.Config:
+		return memlru.NewWithBackend[T](backend)
+
+	default:
+		return nil, fmt.Errorf("cachestorectl: unknown cachestore backend %T", t)
+
+	}
+}

--- a/cachestorectl/cachestorectl.go
+++ b/cachestorectl/cachestorectl.go
@@ -9,14 +9,14 @@ import (
 	"github.com/goware/cachestore/redis"
 )
 
-func Open[T any](backend cachestore.Backend) (cachestore.Store[T], error) {
+func Open[T any](backend cachestore.Backend, opts ...cachestore.StoreOptions) (cachestore.Store[T], error) {
 	switch t := backend.(type) {
 
 	case *memlru.Config:
-		return memlru.NewWithBackend[T](backend)
+		return memlru.NewWithBackend[T](backend, opts...)
 
 	case *redis.Config:
-		return redis.NewWithBackend[T](backend)
+		return redis.NewWithBackend[T](backend, opts...)
 
 	case *nostore.Config:
 		return nostore.New[T]()

--- a/cachestorectl/cachestorectl.go
+++ b/cachestorectl/cachestorectl.go
@@ -5,15 +5,21 @@ import (
 
 	"github.com/goware/cachestore"
 	"github.com/goware/cachestore/memlru"
+	"github.com/goware/cachestore/nostore"
+	"github.com/goware/cachestore/redis"
 )
 
 func Open[T any](backend cachestore.Backend) (cachestore.Store[T], error) {
-	config := backend.Config()
-
-	switch t := config.(type) {
+	switch t := backend.(type) {
 
 	case *memlru.Config:
 		return memlru.NewWithBackend[T](backend)
+
+	case *redis.Config:
+		return redis.NewWithBackend[T](backend)
+
+	case *nostore.Config:
+		return nostore.New[T]()
 
 	default:
 		return nil, fmt.Errorf("cachestorectl: unknown cachestore backend %T", t)

--- a/memlru/config.go
+++ b/memlru/config.go
@@ -1,0 +1,12 @@
+package memlru
+
+import "github.com/goware/cachestore"
+
+type Config struct {
+	cachestore.StoreOptions
+	Size int
+}
+
+func (c *Config) Apply(options *cachestore.StoreOptions) {
+	c.StoreOptions.Apply(options)
+}

--- a/memlru/memlru.go
+++ b/memlru/memlru.go
@@ -34,10 +34,13 @@ func Backend(size int, opts ...cachestore.StoreOptions) cachestore.Backend {
 	}
 }
 
-func NewWithBackend[V any](backend cachestore.Backend) (cachestore.Store[V], error) {
+func NewWithBackend[V any](backend cachestore.Backend, opts ...cachestore.StoreOptions) (cachestore.Store[V], error) {
 	cfg, ok := backend.(*Config)
 	if !ok {
 		return nil, fmt.Errorf("memlru: invalid backend config supplied")
+	}
+	for _, opt := range opts {
+		opt.Apply(&cfg.StoreOptions)
 	}
 	return NewWithSize[V](cfg.Size, cfg.StoreOptions)
 }

--- a/nostore/nostore.go
+++ b/nostore/nostore.go
@@ -11,6 +11,20 @@ var _ cachestore.Store[any] = &NoStore[any]{}
 
 type NoStore[V any] struct{}
 
+type Config struct {
+	cachestore.StoreOptions
+}
+
+func (c *Config) Apply(options *cachestore.StoreOptions) {
+	c.StoreOptions.Apply(options)
+}
+
+func Backend() cachestore.Backend {
+	return &Config{
+		StoreOptions: cachestore.StoreOptions{},
+	}
+}
+
 func New[V any]() (cachestore.Store[V], error) {
 	return &NoStore[V]{}, nil
 }

--- a/options.go
+++ b/options.go
@@ -8,11 +8,9 @@ func ApplyOptions(opts ...StoreOptions) StoreOptions {
 			Apply: func(opts *StoreOptions) {},
 		}
 	}
-	so := StoreOptions{}
+	so := opts[0]
 	for _, opt := range opts {
-		if opt.Apply != nil {
-			opt.Apply(&so)
-		}
+		opt.Apply(&so)
 	}
 	return so
 }

--- a/options.go
+++ b/options.go
@@ -4,11 +4,15 @@ import "time"
 
 func ApplyOptions(opts ...StoreOptions) StoreOptions {
 	if len(opts) == 0 {
-		return StoreOptions{}
+		return StoreOptions{
+			Apply: func(opts *StoreOptions) {},
+		}
 	}
 	so := StoreOptions{}
 	for _, opt := range opts {
-		opt.Apply(&so)
+		if opt.Apply != nil {
+			opt.Apply(&so)
+		}
 	}
 	return so
 }

--- a/redis/config.go
+++ b/redis/config.go
@@ -1,8 +1,13 @@
 package redis
 
-import "time"
+import (
+	"time"
+
+	"github.com/goware/cachestore"
+)
 
 type Config struct {
+	cachestore.StoreOptions
 	Enabled   bool          `toml:"enabled"`
 	Host      string        `toml:"host"`
 	Port      uint16        `toml:"port"`
@@ -10,4 +15,8 @@ type Config struct {
 	MaxIdle   int           `toml:"max_idle"`   // default 4
 	MaxActive int           `toml:"max_active"` // default 8
 	KeyTTL    time.Duration `toml:"key_ttl"`    // default 1 day
+}
+
+func (c *Config) Apply(options *cachestore.StoreOptions) {
+	c.StoreOptions.Apply(options)
 }

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -12,6 +12,20 @@ import (
 	"github.com/goware/cachestore"
 )
 
+type backend struct {
+	config *Config
+}
+
+func (b *backend) Config() any {
+	return b.config
+}
+
+func Backend(cfg *Config) cachestore.Backend {
+	return &backend{
+		config: cfg,
+	}
+}
+
 const LongTime = time.Second * 24 * 60 * 60 // 1 day in seconds
 
 var _ cachestore.Store[any] = &RedisStore[any]{}


### PR DESCRIPTION
introducing new `cachestorectl` package and `cachestore.Backend` type which lets us specify a backend cachestore, and where we can defer the opening of the store in some later part of the code. We also also override options at opening, or set the defaults on the backend.

This is useful for situations where in your program you want to init the cachestore.Backend, depending on the config it might be memlru or redis (or other), and then later in your program you want to pass the cachestore.Backend without specifying the actually `Store[V]` type, and instantiating the store later. The main benefit is for generics / type-safety, so you can open the backend with any kind of type depending on which type the part of your code wants to cache.