### PR TITLE
Small invcache listener refactor

### DIFF
--- a/invstore/invalidating_store_listener_test.go
+++ b/invstore/invalidating_store_listener_test.go
@@ -250,7 +250,7 @@ func TestCacheInvalidator_Listen(t *testing.T) {
 
 			logger := logger.Nop()
 			ic := invstore.NewInvalidatingStore(store, mps)
-			ci := invstore.NewStoreInvalidator(logger, *ic, mps)
+			ci := invstore.NewStoreInvalidator(logger, ic, mps)
 
 			var wg sync.WaitGroup
 			wg.Add(1)


### PR DESCRIPTION
Export local invalidation methods and make listener non-generic(actual data type is not required here, we are just calculating hash) to allow easy multi-store setups and other custom store implementations.